### PR TITLE
Add raw_crop for Canon EOS R7

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -1231,7 +1231,8 @@ Camera constants:
 
     { // Quality C
         "make_model": "Canon EOS R7",
-        "dcraw_matrix" : [10424, -3138, -1300, -4221, 11938,  2584,  -547,  1658,  6183]
+        "dcraw_matrix" : [10424, -3138, -1300, -4221, 11938,  2584,  -547,  1658,  6183],
+        "raw_crop": [ 144, 72, 6984, 4660 ]
     },
 
     { // Quality C


### PR DESCRIPTION
Thanks for your PR.
I have found that images from my R7 have black lines. So I have added raw_crop stolen from 90D which have a similar sensor.

Hope this helps